### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/src/EditView.cxx
+++ b/src/EditView.cxx
@@ -996,7 +996,7 @@ void EditView::DrawEOL(Surface *surface, const EditModel &model, const ViewStyle
 					ctrlChar = repr->stringRep.c_str();
 					eolPos = ll->numCharsInLine;
 				} else {
-					sprintf(hexits, "x%2X", chEOL);
+					snprintf(hexits, sizeof(hexits), "x%2X", chEOL);
 					ctrlChar = hexits;
 				}
 			}

--- a/src/Editor.cxx
+++ b/src/Editor.cxx
@@ -241,7 +241,7 @@ void Editor::SetRepresentations() {
 		for (int k=0x80; k < 0x100; k++) {
 			const char hiByte[2] = {  static_cast<char>(k), 0 };
 			char hexits[5];	// Really only needs 4 but that causes warning from gcc 7.1
-			sprintf(hexits, "x%2X", k);
+			snprintf(hexits, sizeof(hexits), "x%2X", k);
 			reprs.SetRepresentation(hiByte, hexits);
 		}
 	} else if (pdoc->dbcsCodePage) {
@@ -251,7 +251,7 @@ void Editor::SetRepresentations() {
 			if (pdoc->IsDBCSLeadByteNoExcept(ch)  || pdoc->IsDBCSLeadByteInvalid(ch)) {
 				const char hiByte[2] = { ch, 0 };
 				char hexits[5];	// Really only needs 4 but that causes warning from gcc 7.1
-				sprintf(hexits, "x%2X", k);
+				snprintf(hexits, sizeof(hexits), "x%2X", k);
 				reprs.SetRepresentation(hiByte, hexits);
 			}
 		}

--- a/src/MarginView.cxx
+++ b/src/MarginView.cxx
@@ -379,16 +379,21 @@ void MarginView::PaintMargin(Surface *surface, Sci::Line topLine, PRectangle rc,
 							char number[100] = "";
 							if (model.foldFlags & SC_FOLDFLAG_LEVELNUMBERS) {
 								const int lev = model.pdoc->GetLevel(lineDoc);
-								sprintf(number, "%c%c %03X %03X",
-									(lev & SC_FOLDLEVELHEADERFLAG) ? 'H' : '_',
-									(lev & SC_FOLDLEVELWHITEFLAG) ? 'W' : '_',
-									LevelNumber(lev),
-									lev >> 16
-									);
-							} else {
+                                                                snprintf(
+                                                                    number, sizeof(number),
+                                                                    "%c%c %03X %03X",
+                                                                    (lev & SC_FOLDLEVELHEADERFLAG)
+                                                                        ? 'H'
+                                                                        : '_',
+                                                                    (lev & SC_FOLDLEVELWHITEFLAG)
+                                                                        ? 'W'
+                                                                        : '_',
+                                                                    LevelNumber(lev), lev >> 16);
+                                                        } else {
 								const int state = model.pdoc->GetLineState(lineDoc);
-								sprintf(number, "%0X", state);
-							}
+                                                                snprintf(number, sizeof(number),
+                                                                         "%0X", state);
+                                                        }
 							sNumber = number;
 						}
 						PRectangle rcNumber = rcMarker;


### PR DESCRIPTION
snprintf is more secure by design as it considers the size of the target character array. See snprintf(3) for more detail.

This fixes compiler warnings.